### PR TITLE
refactor: replace ENV_VAR_REGEX with findEnvVariables for safer environment variable handling

### DIFF
--- a/src/utils/__tests__/file.test.ts
+++ b/src/utils/__tests__/file.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { ENV_VAR_REGEX, isEnvFile } from '../file';
+import { findEnvVariables, isEnvFile } from '../file';
 
 describe('file utils', () => {
   describe('isEnvFile', () => {
@@ -33,10 +33,10 @@ describe('file utils', () => {
     });
   });
 
-  describe('ENV_VAR_REGEX', () => {
+  describe('findEnvVariables', () => {
     it('should match simple key-value pairs', () => {
       const text = 'API_KEY=abc123';
-      const matches = [...text.matchAll(ENV_VAR_REGEX)];
+      const matches = findEnvVariables(text);
 
       expect(matches.length).toBe(1);
       expect(matches[0][1]).toBe('API_KEY');
@@ -45,7 +45,7 @@ describe('file utils', () => {
 
     it('should match key-value pairs with export', () => {
       const text = 'export DATABASE_URL=postgres://user:pass@localhost:5432/db';
-      const matches = [...text.matchAll(ENV_VAR_REGEX)];
+      const matches = findEnvVariables(text);
 
       expect(matches.length).toBe(1);
       expect(matches[0][1]).toBe('DATABASE_URL');
@@ -54,7 +54,7 @@ describe('file utils', () => {
 
     it('should match keys with underscores and numbers', () => {
       const text = 'API_KEY_2=abc123';
-      const matches = [...text.matchAll(ENV_VAR_REGEX)];
+      const matches = findEnvVariables(text);
 
       expect(matches.length).toBe(1);
       expect(matches[0][1]).toBe('API_KEY_2');
@@ -63,7 +63,7 @@ describe('file utils', () => {
 
     it('should match values with spaces', () => {
       const text = 'MESSAGE=Hello World';
-      const matches = [...text.matchAll(ENV_VAR_REGEX)];
+      const matches = findEnvVariables(text);
 
       expect(matches.length).toBe(1);
       expect(matches[0][1]).toBe('MESSAGE');
@@ -75,7 +75,7 @@ describe('file utils', () => {
 DATABASE_URL=postgres://localhost:5432/db
 export DEBUG=true`;
 
-      const matches = [...text.matchAll(ENV_VAR_REGEX)];
+      const matches = findEnvVariables(text);
       expect(matches.length).toBe(3);
     });
 
@@ -88,7 +88,7 @@ export DEBUG=true`;
       ];
 
       for (const line of invalidLines) {
-        const matches = [...line.matchAll(ENV_VAR_REGEX)];
+        const matches = findEnvVariables(line);
         expect(matches.length).toBe(0);
       }
     });

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,8 +1,25 @@
 /**
  * Regular expression to match environment variable declarations
  * Matches lines like: KEY=value or export KEY=value
+ * Note: Removed global flag to prevent state issues
  */
-export const ENV_VAR_REGEX = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/gm;
+const ENV_VAR_BASE_REGEX = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/m;
+
+/**
+ * Find all environment variable matches in the given text
+ * Returns an array of matches with index information
+ */
+export function findEnvVariables(text: string): RegExpMatchArray[] {
+  // Use matchAll with global flag for safe iteration
+  const globalRegex = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/gm;
+  return Array.from(text.matchAll(globalRegex));
+}
+
+/**
+ * Regular expression to match environment variable declarations (for backward compatibility)
+ * @deprecated Use findEnvVariables() instead for safer regex handling
+ */
+export const ENV_VAR_REGEX = ENV_VAR_BASE_REGEX;
 
 /**
  * Check if a file is an environment file


### PR DESCRIPTION
This PR refactors the handling of environment variable matching to improve safety and maintainability. The primary change replaces the use of `ENV_VAR_REGEX` with a new `findEnvVariables` function, which addresses state issues with the regex and provides a safer API. Corresponding updates have been made to the `Camouflage` class and related tests.