### PR TITLE
feat: add multi-format support for PHP, YAML, and custom file patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,31 @@ Right-click on any line in your `.env` file to access these options:
 - `Ctrl+Shift+T` / `Cmd+Shift+T`: Toggle the value under cursor
 - `Ctrl+Shift+S` / `Cmd+Shift+S`: Toggle selective hiding mode
 
+## Working with Any File Type
+
+Camouflage now supports any file type through configurable file patterns! You can use it with:
+
+- Configuration files: `config.json`, `settings.yaml`, `app.properties`
+- Environment files: `.env`, `.env.local`, `development.env`
+- Custom config files: `secrets.txt`, `api-keys.conf`
+
+Simply configure the `camouflage.files.patterns` setting with the file patterns you want to support.
+
+### Example Configuration
+
+```json
+{
+  "camouflage.files.patterns": [
+    "*.env",          // Any .env files
+    ".env*",          // Any files starting with .env
+    "config.*",       // Any config files
+    "*.conf",         // Any .conf files
+    "secrets*",       // Any files starting with "secrets"
+    "api-keys.json"   // Specific file name
+  ]
+}
+```
+
 ## Configuration
 
 Access settings through:
@@ -95,7 +120,7 @@ Access settings through:
 
 #### Files
 
-- `camouflage.files.patterns`: File patterns to apply hiding (e.g., .env, .env.local)
+- `camouflage.files.patterns`: File patterns to apply hiding (supports glob patterns like `*.env`, `.env*`, `config.*`, etc.)
 
 #### Appearance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camouflage",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camouflage",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "camouflage",
   "displayName": "Camouflage",
-  "description": "Hide sensitive environment values in .env files",
+  "description": "Hide sensitive values in configuration files",
   "version": "1.1.1",
   "publisher": "zeybek",
   "author": {
@@ -22,9 +22,6 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:dotenv",
-    "onLanguage:properties",
-    "onLanguage:plaintext",
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
@@ -88,7 +85,7 @@
         "camouflage.autoHide": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically hide values when opening .env files",
+          "description": "Automatically hide values when opening files matching the configured patterns",
           "category": "General"
         },
         "camouflage.files.patterns": {
@@ -100,7 +97,7 @@
             ".env*",
             "*.env"
           ],
-          "description": "File patterns to apply hiding (e.g., .env, .env.local, etc.)",
+          "description": "File patterns to apply hiding (supports glob patterns like *.env, .env*, config.*, etc.)",
           "category": "Files"
         },
         "camouflage.appearance.hiddenText": {
@@ -167,7 +164,7 @@
         },
         "camouflage.hover.message": {
           "type": "string",
-          "default": "Environment value hidden by Camouflage extension",
+          "default": "Value hidden by Camouflage extension",
           "description": "Custom message to show on hover",
           "category": "Hover"
         },
@@ -184,9 +181,11 @@
             "*PWD*",
             "*DB*",
             "*DATABASE*",
-            "*PORT*"
+            "*PORT*",
+            "*API*",
+            "*AUTH*"
           ],
-          "description": "Patterns to match keys that should always be hidden",
+          "description": "Patterns to match keys/variables that should always be hidden",
           "category": "Selective Hiding"
         },
         "camouflage.selective.enabled": {
@@ -211,68 +210,64 @@
         "command": "camouflage.hide",
         "key": "ctrl+shift+h",
         "mac": "cmd+shift+h",
-        "when": "editorTextFocus && resourceFilename =~ /.*env.*/"
+        "when": "editorTextFocus"
       },
       {
         "command": "camouflage.reveal",
         "key": "ctrl+shift+r",
         "mac": "cmd+shift+r",
-        "when": "editorTextFocus && resourceFilename =~ /.*env.*/"
+        "when": "editorTextFocus"
       },
       {
         "command": "camouflage.toggleValue",
         "key": "ctrl+shift+t",
         "mac": "cmd+shift+t",
-        "when": "editorTextFocus && resourceFilename =~ /.*env.*/"
+        "when": "editorTextFocus"
       },
       {
         "command": "camouflage.toggleSelective",
         "key": "ctrl+shift+s",
         "mac": "cmd+shift+s",
-        "when": "editorTextFocus && resourceFilename =~ /.*env.*/"
+        "when": "editorTextFocus"
       }
     ],
     "menus": {
       "editor/context": [
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/ && config.camouflage.enabled == false",
+          "when": "config.camouflage.enabled == false",
           "command": "camouflage.hide",
           "group": "camouflage@1"
         },
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/ && config.camouflage.enabled == true",
+          "when": "config.camouflage.enabled == true",
           "command": "camouflage.reveal",
           "group": "camouflage@1"
         },
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/",
           "command": "camouflage.toggleValue",
           "group": "camouflage@2"
         },
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/",
           "command": "camouflage.toggleSelective",
           "group": "camouflage@3"
         },
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/",
           "command": "camouflage.addToExcludeList",
           "group": "camouflage@4"
         },
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/",
           "submenu": "camouflage.styleSubMenu",
           "group": "camouflage@5"
         }
       ],
       "editor/title": [
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/ && config.camouflage.enabled == false",
+          "when": "config.camouflage.enabled == false",
           "command": "camouflage.hide",
           "group": "navigation"
         },
         {
-          "when": "resourceExtname == .env || resourceFilename =~ /.*env.*/ && config.camouflage.enabled == true",
+          "when": "config.camouflage.enabled == true",
           "command": "camouflage.reveal",
           "group": "navigation"
         }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,9 +1,31 @@
+import * as vscode from 'vscode';
+import { matchesAnyPattern } from './pattern-matcher';
+
 /**
  * Regular expression to match environment variable declarations
  * Matches lines like: KEY=value or export KEY=value
  * Note: Removed global flag to prevent state issues
  */
 const ENV_VAR_BASE_REGEX = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/m;
+
+/**
+ * Regular expression to match PHP define() statements
+ * Matches lines like: define('KEY', 'value'); or define("KEY", "value");
+ */
+const PHP_DEFINE_REGEX =
+  /define\s*\(\s*['"]([A-Za-z_][A-Za-z0-9_]*)['"],\s*['"]([^'"]*)['"]\s*\)/gm;
+
+/**
+ * Regular expression to match PHP array syntax
+ * Matches lines like: 'key' => 'value', or "key" => "value",
+ */
+const PHP_ARRAY_REGEX = /['"]([A-Za-z_][A-Za-z0-9_]*)['"],?\s*=>\s*['"]([^'"]*)['"]/gm;
+
+/**
+ * Regular expression to match YAML/JSON key-value pairs
+ * Matches lines like: key: value or "key": "value"
+ */
+const YAML_JSON_REGEX = /['"]?([A-Za-z_][A-Za-z0-9_]*)['"]?\s*:\s*['"]([^'"]*)['"]/gm;
 
 /**
  * Regular expression to match commented environment variable declarations
@@ -14,19 +36,44 @@ const COMMENTED_ENV_VAR_REGEX = /^\s*#\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\
 /**
  * Find all environment variable matches in the given text
  * Returns an array of matches with index information
+ * Supports multiple formats: KEY=value, define('KEY', 'value'), 'key' => 'value', key: "value"
  */
 export function findEnvVariables(text: string): RegExpMatchArray[] {
-  // Use matchAll with global flag for safe iteration
-  const globalRegex = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/gm;
-  return Array.from(text.matchAll(globalRegex));
+  const matches: RegExpMatchArray[] = [];
+
+  // Standard KEY=value format
+  const envRegex = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/gm;
+  matches.push(...Array.from(text.matchAll(envRegex)));
+
+  // PHP define() format
+  matches.push(...Array.from(text.matchAll(PHP_DEFINE_REGEX)));
+
+  // PHP array format
+  matches.push(...Array.from(text.matchAll(PHP_ARRAY_REGEX)));
+
+  // YAML/JSON format
+  matches.push(...Array.from(text.matchAll(YAML_JSON_REGEX)));
+
+  return matches;
 }
 
 /**
  * Find all commented environment variable matches in the given text
  * Returns an array of matches with index information for commented lines
+ * Supports commented PHP define() statements and standard formats
  */
 export function findCommentedEnvVariables(text: string): RegExpMatchArray[] {
-  return Array.from(text.matchAll(COMMENTED_ENV_VAR_REGEX));
+  const matches: RegExpMatchArray[] = [];
+
+  // Standard commented format: # KEY=value
+  matches.push(...Array.from(text.matchAll(COMMENTED_ENV_VAR_REGEX)));
+
+  // PHP commented define() format: // define('KEY', 'value');
+  const commentedPhpDefineRegex =
+    /\/\/\s*define\s*\(\s*['"]([A-Za-z_][A-Za-z0-9_]*)['"],\s*['"]([^'"]*)['"]\s*\)/gm;
+  matches.push(...Array.from(text.matchAll(commentedPhpDefineRegex)));
+
+  return matches;
 }
 
 /**
@@ -50,12 +97,17 @@ export function findAllEnvVariables(text: string): {
 export const ENV_VAR_REGEX = ENV_VAR_BASE_REGEX;
 
 /**
- * Check if a file is an environment file
+ * Check if a file matches the configured file patterns
  */
 export function isEnvFile(fileName: string): boolean {
-  return (
-    fileName.toLowerCase().endsWith('.env') ||
-    fileName.toLowerCase().includes('.env.') ||
-    fileName.toLowerCase().includes('.envrc')
-  );
+  // Get file patterns from configuration
+  const filePatterns = vscode.workspace
+    .getConfiguration('camouflage')
+    .get('files.patterns', ['.env*', '*.env']) as string[];
+
+  // Extract just the filename from the full path
+  const basename = fileName.split('/').pop() || fileName.split('\\').pop() || fileName;
+
+  // Check if the filename matches any of the configured patterns
+  return matchesAnyPattern(basename, filePatterns);
 }


### PR DESCRIPTION
## Feature: Multi-Format Support

This PR extends Camouflage to work with any file type beyond .env files.

### added
- **PHP Support**: `define('API_KEY', 'secret')` and `'key' => 'value'` syntax
- **YAML/JSON Support**: `key: "value"` syntax  
- **Configurable Patterns**: `*.php`, `config.*`, `*.yaml`, etc.
- **Broader Compatibility**: Works with any configuration file format

###  Testing
- Added  tests for PHP define() statements
- Added tests for PHP array syntax
- Added tests for YAML/JSON formats
- All existing tests pass

### Documentation
- Updated README with multi-format examples
- Added configuration examples for different file types

### Changes
- Extended regex patterns in `src/utils/file.ts`
- Removed hardcoded .env restrictions from package.json
- Updated file detection to use configurable patterns


### Example 
```json
{
  "camouflage.files.patterns": [
    "*.php",      // PHP config files
    "config.*",   // Any config files
    "*.yaml",     // YAML files
    "*.env"       // Still supports .env
  ]
}
```