### PR TITLE
fix(parsers): hide all duplicate key occurrences in JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "camouflage",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "camouflage",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
@@ -252,7 +252,6 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2226,7 +2225,6 @@
       "integrity": "sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -3374,7 +3372,6 @@
       "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3453,7 +3450,6 @@
       "integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.26.0",
         "@typescript-eslint/types": "8.26.0",
@@ -4202,7 +4198,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4633,7 +4628,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5576,7 +5570,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -6338,7 +6331,6 @@
       "integrity": "sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8207,7 +8199,6 @@
       "integrity": "sha512-HlSEiHRcmTuGwNyeawLTEzpQUMFn+f741FfoNg7RXG2h0WLJKozVCpcQLT0GW17H6kNCqRwGf+Ii/I1YVNvEGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.2",
         "@jest/types": "30.0.1",
@@ -10223,7 +10214,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -14596,7 +14586,6 @@
       "integrity": "sha512-9xV49HNY8C0/WmPWxTlaNleiXhWb//qfMzG2c5X8/k7tuWcu8RssbuS+sujb/h7PiWSXv53mrQvV9hrO9b7vuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -16093,7 +16082,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/parsers/json-parser.ts
+++ b/src/parsers/json-parser.ts
@@ -20,8 +20,10 @@ export class JsonParser extends BaseParser {
       // Parse the JSON to get structure
       const parsed = JSON.parse(content);
 
-      // Recursively extract variables
-      this.extractVariables(parsed, content, '', 0, variables);
+      // Recursively extract variables, advancing a shared search cursor so
+      // duplicate key+value pairs (e.g. arrays of objects) map to distinct
+      // source positions instead of all collapsing onto the first match.
+      this.extractVariables(parsed, content, '', 0, variables, { offset: 0 });
     } catch {
       // If JSON is invalid, try to parse what we can using regex
       this.parseWithRegex(content, variables);
@@ -38,7 +40,8 @@ export class JsonParser extends BaseParser {
     content: string,
     keyPrefix: string,
     depth: number,
-    variables: ParsedVariable[]
+    variables: ParsedVariable[],
+    cursor: { offset: number }
   ): void {
     if (depth > this.options.maxNestedDepth) {
       return;
@@ -52,8 +55,9 @@ export class JsonParser extends BaseParser {
       const fullKey = keyPrefix ? `${keyPrefix}.${key}` : key;
 
       if (typeof value === 'string') {
-        // Find the position of this key-value in the original content
-        const position = this.findValuePosition(content, key, value);
+        // Find the position of this key-value starting from the cursor so
+        // repeated occurrences of the same key+value are matched in order.
+        const position = this.findValuePosition(content, key, value, cursor.offset);
         if (position) {
           variables.push(
             this.createVariable(
@@ -66,10 +70,11 @@ export class JsonParser extends BaseParser {
               false
             )
           );
+          cursor.offset = position.endIndex;
         }
       } else if (typeof value === 'object' && value !== null) {
         // Recurse into nested objects
-        this.extractVariables(value, content, fullKey, depth + 1, variables);
+        this.extractVariables(value, content, fullKey, depth + 1, variables, cursor);
       }
     }
   }
@@ -80,7 +85,8 @@ export class JsonParser extends BaseParser {
   private findValuePosition(
     content: string,
     key: string,
-    value: string
+    value: string,
+    fromIndex: number = 0
   ): { startIndex: number; endIndex: number } | null {
     // Escape special regex characters in key and value
     const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -88,6 +94,7 @@ export class JsonParser extends BaseParser {
 
     // Match "key": "value" pattern
     const pattern = new RegExp(`"${escapedKey}"\\s*:\\s*"(${escapedValue})"`, 'g');
+    pattern.lastIndex = fromIndex;
 
     const match: RegExpExecArray | null = pattern.exec(content);
     if (match) {


### PR DESCRIPTION
## Description 📝

JSON parser was reporting every duplicate `"key": "value"` match at the first occurrence's position because `findValuePosition` re-ran a fresh global regex from index 0 on each AST node. In arrays of objects or sibling nested objects sharing a key and a value, decorations collapsed onto the first match and later occurrences stayed visible.

The fix threads a shared source cursor through `extractVariables` and advances `pattern.lastIndex` so each match resumes past the previous one. AST iteration order follows source order (JSON preserves insertion order), so cursor advancement is safe.

Fixes #16

## Type of change 🏷️

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested? 🧪

- [x] Added regression suite `src/parsers/__tests__/json-parser-duplicates.test.ts` covering:
  - Array of objects with identical key+value pairs
  - Sibling nested objects with identical key+value pairs
  - Array of objects with different values (control, already worked)
- [x] Verified existing `json-parser.test.ts` still passes (17/17)
- [x] Full test suite green locally (285/285)

## Checklist ✅

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots 📸

<!-- Add screenshots here if applicable -->

## Additional context 📌

Only the JSON parser is affected. YAML, env, properties and TOML parsers walk content line-by-line with a tracked cursor, so they already emit distinct positions for duplicate keys. The regex fallback path in `parseWithRegex` was also already correct (it advances `lastIndex` inside a `while` loop).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing behavior for handling duplicate key-value pairs. The parser now correctly matches repeated keys sequentially by their order of appearance in the file, rather than mapping all occurrences to the first match position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->